### PR TITLE
Update OneLogin dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This is not a long term solution, merely a messy gross fix to bridge the gap.
 
+anyone else that stumbles across it: <a href='https://www.amitmerchant.com/how-to-pull-github-repositories-as-composer-packages-in-php/'>installation instructions</a>
+
 Provides Saml2 Authentication Middleware for a Laravel App.  If you like this, checkout <a href="https://github.com/rootinc/laravel-azure-middleware">Laravel Azure Middleware</a>
 
 ## Normal Installation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Laravel Saml2 Middleware
 
+## This fork only changes the upstream deps (OneLogin) to resolve <a href='https://github.com/onelogin/php-saml/issues/453'>libxml_disable_entity_loader() is deprecated</a> for PHP 8+
+
+This is not a long term solution, merely a messy gross fix to bridge the gap.
+
 Provides Saml2 Authentication Middleware for a Laravel App.  If you like this, checkout <a href="https://github.com/rootinc/laravel-azure-middleware">Laravel Azure Middleware</a>
 
 ## Normal Installation

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Laravel Saml2 Middleware
 
-## This fork only changes the upstream deps (OneLogin) to resolve <a href='https://github.com/onelogin/php-saml/issues/453'>libxml_disable_entity_loader() is deprecated</a> for PHP 8+
-
-This is not a long term solution, merely a messy gross fix to bridge the gap.
-
 Provides Saml2 Authentication Middleware for a Laravel App.  If you like this, checkout <a href="https://github.com/rootinc/laravel-azure-middleware">Laravel Azure Middleware</a>
 
 ## Normal Installation

--- a/composer.json
+++ b/composer.json
@@ -3,15 +3,20 @@
     "description": "Saml2 Middleware Auth",
     "type": "library",
     "require": {
-        "php": ">=5.6.4",
-        "laravel/framework": ">=5.4.0",
-        "onelogin/php-saml": "^3.3"
+        "php": ">=8",
+        "laravel/framework": ">=8",
+        "onelogin/php-saml": "^4"
     },
     "license": "MIT",
-    "authors": [
-        {
+    "authors": [{
             "name": "Root Inc",
             "email": "djewett@rootinc.com"
+        },
+        {
+            "name": "Lloyd Culpepper",
+            "email": "lloyd.culpepper@onlinehomeretai.co.uk",
+            "homepage": "https://lloydculpepper.com",
+            "role": "Forker"
         }
     ],
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "Saml2 Middleware Auth",
     "type": "library",
     "require": {
-        "php": ">=8",
-        "laravel/framework": ">=8",
+        "php": ">=7.3",
+        "laravel/framework": ">=5.4.0",
         "onelogin/php-saml": "^4"
     },
     "license": "MIT",
@@ -14,8 +14,8 @@
         },
         {
             "name": "Lloyd Culpepper",
-            "email": "lloyd.culpepper@onlinehomeretai.co.uk",
-            "homepage": "https://lloydculpepper.com",
+            "email": "lloyd.culpepper@onlinehomeretail.co.uk",
+            "homepage": "https://lloydculpepper.uk",
             "role": "Forker"
         }
     ],


### PR DESCRIPTION
Fixes https://github.com/rootinc/laravel-saml2-middleware/issues/5

- might break compatibility for PHP 5.x as deprecated XML functions have been replaced
- composer.json has been updated requiring min PHP7.3 but may work with older versions.